### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -32,5 +32,6 @@ jobs:
         run: |
           cd Ruby/exercises/
           gem install bundler
-          bundle install --path vendor/bundle --quiet --jobs 4 --retry 3
+          bundle config set path 'vendor/bundle'
+          bundle install --quiet --jobs 4 --retry 3
           bundle exec rspec


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts how dependencies are installed; impact is limited to the GitHub Actions rspec job.
> 
> **Overview**
> Updates the `RSPEC` GitHub Actions workflow to set Bundler’s install directory with `bundle config set path 'vendor/bundle'`, then runs `bundle install` without the deprecated `--path` flag before executing `rspec`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7645e9b07b66e5e15debcbf8e6a3520c33140ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->